### PR TITLE
Rename suborderGroup->reference in client.json

### DIFF
--- a/src/Ice/MinervaClientBundle/Resources/config/client.json
+++ b/src/Ice/MinervaClientBundle/Resources/config/client.json
@@ -454,7 +454,7 @@
                 }
             }
         },
-        "CreateBooking": {
+        "PutBooking": {
             "httpMethod": "PUT",
             "uri": "api/bookings/{username}/{courseId}",
             "summary": "Create an empty booking",

--- a/src/Ice/MinervaClientBundle/Resources/config/client.json
+++ b/src/Ice/MinervaClientBundle/Resources/config/client.json
@@ -477,7 +477,7 @@
                     "required":true,
                     "type":"string"
                 },
-                "suborderGroup": {
+                "reference": {
                     "location":"json",
                     "required":false,
                     "type":"string"

--- a/src/Ice/MinervaClientBundle/Service/MinervaClient.php
+++ b/src/Ice/MinervaClientBundle/Service/MinervaClient.php
@@ -412,7 +412,7 @@ class MinervaClient
         ));
 
         try{
-            $this->client->getCommand('CreateBooking', $values)->execute();
+            $this->client->getCommand('PutBooking', $values)->execute();
         }
         catch(\Guzzle\Http\Exception\ClientErrorResponseException $clientErrorResponseException){
             if($clientErrorResponseException->getCode()===400){
@@ -463,7 +463,7 @@ class MinervaClient
         }
 
         try{
-            $this->client->getCommand('CreateBooking', $values)->execute();
+            $this->client->getCommand('PutBooking', $values)->execute();
         }
         catch(\Guzzle\Http\Exception\ClientErrorResponseException $clientErrorResponseException){
             if($clientErrorResponseException->getCode()===400){


### PR DESCRIPTION
To fix a bug where the booking reference was being blanked out in Minerva whenever a booking was updated. This is because the 'CreateBooking' guzzle command was actually being used to update bookings as well - I've renamed this accordingly to PutBooking. 